### PR TITLE
Burn lamports on revoke

### DIFF
--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -5,9 +5,6 @@ use spl_program_error::*;
 /// Program specific errors
 #[spl_program_error]
 pub enum FeatureGateError {
-    /// Operation overflowed
-    #[error("Operation overflowed")]
-    Overflow,
     /// Feature already activated
     #[error("Feature already activated")]
     FeatureAlreadyActivated,


### PR DESCRIPTION
#### Problem
As part of a potentially useful anti-spam mechanism, we can impose a restriction on
revoked features that the lamports be burnt whenever a feature is revoked.

In the future, to add even more spam protection, contributors could impose a
minimum deposit for feature accounts. This burn implementation would work nicely
with such an arrangement.

#### Summary of Changes
Update the instruction and processor for `RevokePendingFeatureActivation` to burn
lamports from the closed feature account.

Note: Luckily the SIMD does not specify what should happen to the lamports...

https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0089-programify-feature-gate-program.md#detailed-design