### PR TITLE
Benchmarking Compute Units

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -109,6 +109,38 @@ jobs:
       - name: Test Programs
         run: pnpm programs:test
 
+  bench_program_compute_units:
+    name: Benchmark Program Compute Units
+    runs-on: ubuntu-latest
+    needs: build_programs # Cargo Bench won't build the SBPF binary...
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup
+        with:
+          cargo-cache-key: cargo-program-benches
+          cargo-cache-fallback-key: cargo-programs
+          solana: true
+
+      - name: Restore Program Builds
+        uses: actions/cache/restore@v4
+        with:
+          path: ./**/*.so
+          key: ${{ runner.os }}-builds-${{ github.sha }}
+
+      - name: Benchmark Compute Units
+        run: pnpm programs:bench
+
+      - name: Check Working Directory
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            test -z "$(git status --porcelain)"
+            echo "CU usage has changed. Please run `cargo bench` and commit the new results.";
+            exit 1;
+          fi
+
   generate_idls:
     name: Check IDL Generation
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2176,6 +2176,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "mollusk-svm-bencher"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19edc6403e493718d693b5faa0b6bcc2aebdd4947dc16c144929dc3d7c5c0f24"
+dependencies = [
+ "chrono",
+ "mollusk-svm",
+ "num-format",
+ "serde_json",
+ "solana-sdk",
+]
+
+[[package]]
 name = "mollusk-svm-fuzz-fixture"
 version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2297,6 +2310,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.72",
+]
+
+[[package]]
+name = "num-format"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
+dependencies = [
+ "arrayvec",
+ "itoa",
 ]
 
 [[package]]
@@ -3940,6 +3963,7 @@ name = "solana-feature-gate-program"
 version = "0.1.0"
 dependencies = [
  "mollusk-svm",
+ "mollusk-svm-bencher",
  "num_enum",
  "shank",
  "solana-program",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "scripts": {
     "programs:build": "zx ./scripts/program/build.mjs",
     "programs:test": "zx ./scripts/program/test.mjs",
+    "programs:bench": "zx ./scripts/program/bench.mjs",
     "programs:clean": "zx ./scripts/program/clean.mjs",
     "programs:format": "zx ./scripts/program/format.mjs",
     "programs:lint": "zx ./scripts/program/lint.mjs",

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -23,7 +23,18 @@ spl-program-error = "0.5.0"
 
 [dev-dependencies]
 mollusk-svm = { version = "0.0.5", features = ["fuzz"] }
+mollusk-svm-bencher = "0.0.5"
 solana-sdk = "2.0.1"
 
 [lib]
 crate-type = ["cdylib", "lib"]
+
+[[bench]]
+name = "compute_units"
+harness = false
+
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = [
+    'cfg(target_os, values("solana"))',
+]

--- a/program/benches/compute_units.md
+++ b/program/benches/compute_units.md
@@ -1,0 +1,6 @@
+#### Compute Units: 2024-10-22 17:38:11.836151 UTC
+
+| Name | CUs | Delta |
+|------|------|-------|
+| revoke_pending_activation | 2781 | - new - |
+

--- a/program/benches/compute_units.rs
+++ b/program/benches/compute_units.rs
@@ -1,0 +1,39 @@
+//! Feature Gate program compute unit benchmark testing.
+
+use {
+    mollusk_svm::{program::keyed_account_for_system_program, Mollusk},
+    mollusk_svm_bencher::{Bench, MolluskComputeUnitBencher},
+    solana_feature_gate_program::instruction::revoke_pending_activation,
+    solana_sdk::{account::AccountSharedData, feature::Feature, incinerator, pubkey::Pubkey},
+};
+
+fn main() {
+    std::env::set_var("SBF_OUT_DIR", "../target/deploy");
+    let mollusk = Mollusk::new(&solana_sdk::feature::id(), "solana_feature_gate_program");
+
+    let feature = Pubkey::new_unique();
+
+    let bench: Bench = (
+        "revoke_pending_activation",
+        &revoke_pending_activation(&feature),
+        &[
+            (
+                feature,
+                AccountSharedData::new_data(
+                    42,
+                    &Feature { activated_at: None },
+                    &solana_sdk::feature::id(),
+                )
+                .unwrap(),
+            ),
+            (incinerator::id(), AccountSharedData::default()),
+            keyed_account_for_system_program(),
+        ],
+    );
+
+    MolluskComputeUnitBencher::new(mollusk)
+        .bench(bench)
+        .must_pass(true)
+        .out_dir("./benches")
+        .execute();
+}

--- a/scripts/program/bench.mjs
+++ b/scripts/program/bench.mjs
@@ -1,0 +1,29 @@
+#!/usr/bin/env zx
+import 'zx/globals';
+import {
+  cliArguments,
+  getProgramFolders,
+  workingDirectory,
+} from '../utils.mjs';
+
+// Save external programs binaries to the output directory.
+import './dump.mjs';
+
+// Configure additional arguments here, e.g.:
+// ['--arg1', '--arg2', ...cliArguments()]
+const benchArgs = cliArguments();
+
+const hasSolfmt = await which('solfmt', { nothrow: true });
+
+// Test the programs.
+await Promise.all(
+  getProgramFolders().map(async (folder) => {
+    const manifestPath = path.join(workingDirectory, folder, 'Cargo.toml');
+
+    if (hasSolfmt) {
+      await $`RUST_LOG=error cargo bench --manifest-path ${manifestPath} ${benchArgs} 2>&1 | solfmt`;
+    } else {
+      await $`RUST_LOG=error cargo bench --manifest-path ${manifestPath} ${benchArgs}`;
+    }
+  })
+);

--- a/scripts/program/build.mjs
+++ b/scripts/program/build.mjs
@@ -11,7 +11,11 @@ import './dump.mjs';
 
 // Configure additional arguments here, e.g.:
 // ['--arg1', '--arg2', ...cliArguments()]
-const buildArgs = cliArguments();
+const buildArgs = [
+  '--features',
+  'bpf-entrypoint',
+  ...cliArguments()
+];
 
 // Build the programs.
 await Promise.all(

--- a/scripts/program/lint.mjs
+++ b/scripts/program/lint.mjs
@@ -12,8 +12,8 @@ import {
 // ['--arg1', '--arg2', ...cliArguments()]
 const lintArgs = [
   '-Zunstable-options',
-  '--features',
-  'bpf-entrypoint,test-sbf',
+  '--all-targets',
+  '--all-features',
   '--',
   '--deny=warnings',
   '--deny=clippy::arithmetic_side_effects',


### PR DESCRIPTION
Benchmarking compute unit usage for the BPF implementation of the
Feature Gate program using [Mollusk](https://github.com/buffalojoec/mollusk).

Mollusk's CU bencher is designed to profile compute unit usage for a series
of benchmark instructions.

The bencher will only write a new table to the markdown file if CU usage has
changed. With this in mind, we can integrate CU benching into our CI so that
if there is ever a change to the program that affects CUs, the file must be
committed with the new benchmarks.