### PR TITLE
Benchmarking Compute: Workflow demonstration

### DIFF
--- a/program/benches/compute_units.md
+++ b/program/benches/compute_units.md
@@ -1,3 +1,9 @@
+#### Compute Units: 2024-06-21 15:56:52.203332 UTC
+
+| Name | Mean | Delta |
+|------|------|-------|
+| revoke_pending_activation | 5874 | +4,884 |
+
 #### Compute Units: 2024-06-21 15:49:53.795114 UTC
 
 | Name | Mean | Delta |

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -10,7 +10,9 @@ use {
         program::invoke,
         program_error::ProgramError,
         pubkey::Pubkey,
+        rent::Rent,
         system_instruction, system_program,
+        sysvar::Sysvar,
     },
 };
 
@@ -37,6 +39,10 @@ pub fn process_revoke_pending_activation(
     {
         return Err(FeatureGateError::FeatureAlreadyActivated.into());
     }
+
+    // Do this unnecessarily to increase compute.
+    let rent = <Rent as Sysvar>::get()?;
+    msg!("Rent: {:?}", rent);
 
     // Clear data and reassign.
     feature_info.realloc(0, true)?;


### PR DESCRIPTION
This PR demonstrates a potential workflow to include in program repositories.

I've set up compute unit benchmarking using [Mollusk](https://github.com/buffalojoec/mollusk) in the base branch.

Then I've made an arbitrary change in the program on the working branch, and
as you can see, the compute unit benchmark has created a new table reflecting
the change in compute units based on my change!

The idea here would be to take inspiration from https://github.com/solana-program/create-solana-program
and use `cargo bench` in CI, then check with `git status --porcelain` to detect
CU usage changes on a pull request, forcing contributors to commit the file if
CU usage has changed as a result of their proposed change.