### PR TITLE
Rewrite tests with mollusk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2150,6 +2150,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "mollusk-svm"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ab64b7fdd65d01453cebbe010715f161f0317303a8d8e9f6b7c88950cbd95f3"
+dependencies = [
+ "bincode",
+ "solana-bpf-loader-program",
+ "solana-compute-budget",
+ "solana-logger",
+ "solana-program-runtime",
+ "solana-sdk",
+ "solana-system-program",
+]
+
+[[package]]
 name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3842,10 +3857,10 @@ dependencies = [
 name = "solana-feature-gate-program"
 version = "0.1.0"
 dependencies = [
+ "mollusk-svm",
  "num_enum",
  "shank",
  "solana-program",
- "solana-program-test",
  "solana-sdk",
  "spl-program-error",
 ]

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -22,7 +22,7 @@ solana-program = "2.0.1"
 spl-program-error = "0.5.0"
 
 [dev-dependencies]
-solana-program-test = "2.0.1"
+mollusk-svm = "0.0.2"
 solana-sdk = "2.0.1"
 
 [lib]

--- a/program/tests/revoke_pending_activation.rs
+++ b/program/tests/revoke_pending_activation.rs
@@ -3,185 +3,113 @@
 mod setup;
 
 use {
-    setup::{setup, setup_active_feature, setup_pending_feature},
+    mollusk_svm::{program::keyed_account_for_system_program, result::Check},
+    setup::{active_feature_account, pending_feature_account, setup},
     solana_feature_gate_program::{
         error::FeatureGateError, instruction::revoke_pending_activation,
     },
-    solana_program::instruction::InstructionError,
-    solana_program_test::*,
     solana_sdk::{
-        account::{Account, AccountSharedData},
-        feature::Feature,
+        account::{AccountSharedData, WritableAccount},
+        incinerator,
+        program_error::ProgramError,
         pubkey::Pubkey,
-        signature::{Keypair, Signer},
-        transaction::{Transaction, TransactionError},
     },
 };
 
-#[tokio::test]
-async fn fail_feature_not_signer() {
-    let mut context = setup().start_with_context().await;
+#[test]
+fn fail_feature_not_signer() {
+    let mollusk = setup();
+    let feature = Pubkey::new_unique();
 
-    let mut instruction = revoke_pending_activation(&Pubkey::new_unique());
+    let mut instruction = revoke_pending_activation(&feature);
     instruction.accounts[0].is_signer = false;
 
-    let transaction = Transaction::new_signed_with_payer(
-        &[instruction],
-        Some(&context.payer.pubkey()),
-        &[&context.payer],
-        context.last_blockhash,
-    );
-
-    let error = context
-        .banks_client
-        .process_transaction(transaction)
-        .await
-        .unwrap_err()
-        .unwrap();
-
-    assert_eq!(
-        error,
-        TransactionError::InstructionError(0, InstructionError::MissingRequiredSignature)
+    mollusk.process_and_validate_instruction(
+        &instruction,
+        &[
+            (feature, pending_feature_account()),
+            (incinerator::id(), AccountSharedData::default()),
+            keyed_account_for_system_program(),
+        ],
+        &[Check::err(ProgramError::MissingRequiredSignature)],
     );
 }
 
-#[tokio::test]
-async fn fail_feature_incorrect_owner() {
-    let feature_keypair = Keypair::new();
-
-    let mut context = setup().start_with_context().await;
+#[test]
+fn fail_feature_incorrect_owner() {
+    let mollusk = setup();
+    let feature = Pubkey::new_unique();
 
     // Set up a feature account with incorrect owner.
-    {
-        context.set_account(
-            &feature_keypair.pubkey(),
-            &AccountSharedData::from(Account {
-                lamports: 100_000_000,
-                data: vec![0; Feature::size_of()],
-                owner: Pubkey::new_unique(), // Incorrect owner.
-                ..Account::default()
-            }),
-        );
-    }
+    let mut feature_account = pending_feature_account();
+    feature_account.set_owner(Pubkey::new_unique());
 
-    let transaction = Transaction::new_signed_with_payer(
-        &[revoke_pending_activation(&feature_keypair.pubkey())],
-        Some(&context.payer.pubkey()),
-        &[&context.payer, &feature_keypair],
-        context.last_blockhash,
-    );
-
-    let error = context
-        .banks_client
-        .process_transaction(transaction)
-        .await
-        .unwrap_err()
-        .unwrap();
-
-    assert_eq!(
-        error,
-        TransactionError::InstructionError(0, InstructionError::InvalidAccountOwner)
+    mollusk.process_and_validate_instruction(
+        &revoke_pending_activation(&feature),
+        &[
+            (feature, feature_account),
+            (incinerator::id(), AccountSharedData::default()),
+            keyed_account_for_system_program(),
+        ],
+        &[Check::err(ProgramError::InvalidAccountOwner)],
     );
 }
 
-#[tokio::test]
-async fn fail_feature_invalid_data() {
-    let feature_keypair = Keypair::new();
-
-    let mut context = setup().start_with_context().await;
+#[test]
+fn fail_feature_invalid_data() {
+    let mollusk = setup();
+    let feature = Pubkey::new_unique();
 
     // Set up a feature account with invalid data.
-    {
-        context.set_account(
-            &feature_keypair.pubkey(),
-            &AccountSharedData::from(Account {
-                lamports: 100_000_000,
-                data: vec![8; Feature::size_of()],
-                owner: solana_feature_gate_program::id(),
-                ..Account::default()
-            }),
-        );
-    }
+    let mut feature_account = pending_feature_account();
+    feature_account.set_data_from_slice(&[2; 8]);
 
-    let transaction = Transaction::new_signed_with_payer(
-        &[revoke_pending_activation(&feature_keypair.pubkey())],
-        Some(&context.payer.pubkey()),
-        &[&context.payer, &feature_keypair],
-        context.last_blockhash,
-    );
-
-    let error = context
-        .banks_client
-        .process_transaction(transaction)
-        .await
-        .unwrap_err()
-        .unwrap();
-
-    assert_eq!(
-        error,
-        TransactionError::InstructionError(0, InstructionError::InvalidAccountData)
+    mollusk.process_and_validate_instruction(
+        &revoke_pending_activation(&feature),
+        &[
+            (feature, feature_account),
+            (incinerator::id(), AccountSharedData::default()),
+            keyed_account_for_system_program(),
+        ],
+        &[Check::err(ProgramError::InvalidAccountData)],
     );
 }
 
-#[tokio::test]
-async fn fail_feature_already_activated() {
-    let feature_keypair = Keypair::new();
+#[test]
+fn fail_feature_already_activated() {
+    let mollusk = setup();
+    let feature = Pubkey::new_unique();
 
-    let mut context = setup().start_with_context().await;
-
-    // Set up an active feature account.
-    setup_active_feature(&mut context, &feature_keypair.pubkey());
-
-    let transaction = Transaction::new_signed_with_payer(
-        &[revoke_pending_activation(&feature_keypair.pubkey())],
-        Some(&context.payer.pubkey()),
-        &[&context.payer, &feature_keypair],
-        context.last_blockhash,
-    );
-
-    let error = context
-        .banks_client
-        .process_transaction(transaction)
-        .await
-        .unwrap_err()
-        .unwrap();
-
-    assert_eq!(
-        error,
-        TransactionError::InstructionError(
-            0,
-            InstructionError::Custom(FeatureGateError::FeatureAlreadyActivated as u32)
-        )
+    mollusk.process_and_validate_instruction(
+        &revoke_pending_activation(&feature),
+        &[
+            (feature, active_feature_account()),
+            (incinerator::id(), AccountSharedData::default()),
+            keyed_account_for_system_program(),
+        ],
+        &[Check::err(ProgramError::Custom(
+            FeatureGateError::FeatureAlreadyActivated as u32,
+        ))],
     );
 }
 
-#[tokio::test]
-async fn success() {
-    let feature_keypair = Keypair::new();
+#[test]
+fn success() {
+    let mollusk = setup();
+    let feature = Pubkey::new_unique();
 
-    let mut context = setup().start_with_context().await;
-
-    // Set up a pending feature account.
-    setup_pending_feature(&mut context, &feature_keypair.pubkey());
-
-    let transaction = Transaction::new_signed_with_payer(
-        &[revoke_pending_activation(&feature_keypair.pubkey())],
-        Some(&context.payer.pubkey()),
-        &[&context.payer, &feature_keypair],
-        context.last_blockhash,
+    mollusk.process_and_validate_instruction(
+        &revoke_pending_activation(&feature),
+        &[
+            (feature, pending_feature_account()),
+            (incinerator::id(), AccountSharedData::default()),
+            keyed_account_for_system_program(),
+        ],
+        &[
+            Check::success(),
+            Check::compute_units(2_781),
+            // Confirm feature account was closed.
+            Check::account(&feature).closed().build(),
+        ],
     );
-
-    context
-        .banks_client
-        .process_transaction(transaction)
-        .await
-        .unwrap();
-
-    // Confirm feature account was closed.
-    let feature_account = context
-        .banks_client
-        .get_account(feature_keypair.pubkey())
-        .await
-        .unwrap();
-    assert!(feature_account.is_none());
 }

--- a/program/tests/setup.rs
+++ b/program/tests/setup.rs
@@ -2,47 +2,45 @@
 #![allow(dead_code)]
 
 use {
-    solana_program_test::*,
+    mollusk_svm::Mollusk,
     solana_sdk::{
         account::{Account, AccountSharedData},
-        pubkey::Pubkey,
+        feature::Feature,
+        rent::Rent,
     },
 };
 
-pub fn setup() -> ProgramTest {
-    ProgramTest::new(
+pub fn setup() -> Mollusk {
+    Mollusk::new(
+        &solana_feature_gate_program::id(),
         "solana_feature_gate_program",
-        solana_feature_gate_program::id(),
-        processor!(solana_feature_gate_program::processor::process),
     )
 }
 
-pub fn setup_pending_feature(context: &mut ProgramTestContext, feature_id: &Pubkey) {
-    context.set_account(
-        feature_id,
-        &AccountSharedData::from(Account {
-            lamports: 100_000_000,
-            data: vec![
-                0, // `None`
-                0, 0, 0, 0, 0, 0, 0, 0,
-            ],
-            owner: solana_feature_gate_program::id(),
-            ..Account::default()
-        }),
-    );
+fn feature_rent() -> u64 {
+    Rent::default().minimum_balance(Feature::size_of())
 }
 
-pub fn setup_active_feature(context: &mut ProgramTestContext, feature_id: &Pubkey) {
-    context.set_account(
-        feature_id,
-        &AccountSharedData::from(Account {
-            lamports: 100_000_000,
-            data: vec![
-                1, // `Some`
-                45, 0, 0, 0, 0, 0, 0, 0, // Random slot `u64`
-            ],
-            owner: solana_feature_gate_program::id(),
-            ..Account::default()
-        }),
-    );
+pub fn pending_feature_account() -> AccountSharedData {
+    AccountSharedData::from(Account {
+        lamports: feature_rent(),
+        data: vec![
+            0, // `None`
+            0, 0, 0, 0, 0, 0, 0, 0,
+        ],
+        owner: solana_feature_gate_program::id(),
+        ..Account::default()
+    })
+}
+
+pub fn active_feature_account() -> AccountSharedData {
+    AccountSharedData::from(Account {
+        lamports: feature_rent(),
+        data: vec![
+            1, // `Some`
+            45, 0, 0, 0, 0, 0, 0, 0, // Random slot `u64`
+        ],
+        owner: solana_feature_gate_program::id(),
+        ..Account::default()
+    })
 }


### PR DESCRIPTION
This PR rewrites all program tests with [Mollusk](https://github.com/buffalojoec/mollusk) instead of `solana-program-test`.