### PR TITLE
implement mollusk conformance testing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -140,6 +140,37 @@ jobs:
             echo "CU usage has changed. Please run `cargo bench` and commit the new results.";
             exit 1;
           fi
+  
+  conformance:
+    name: Conformance Test
+    runs-on: ubuntu-latest
+    needs: build_programs
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v4
+      
+      - name: Setup Environment
+        uses: ./.github/actions/setup
+        with:
+          cargo-cache-key: cargo-program-conformance
+          cargo-cache-fallback-key: cargo-programs
+          solana: true
+      
+      - name: Install System Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libudev-dev pkg-config
+          command -v mollusk >/dev/null 2>&1 || cargo install mollusk-svm-cli
+      
+      - name: Restore Program Builds
+        uses: actions/cache/restore@v4
+        with:
+          path: ./**/*.so
+          key: ${{ runner.os }}-builds-${{ github.sha }}
+      
+      - name: Conformance Test
+        shell: bash
+        run: pnpm zx ./scripts/ci/conformance.mjs
 
   generate_idls:
     name: Check IDL Generation

--- a/scripts/ci/conformance.mjs
+++ b/scripts/ci/conformance.mjs
@@ -1,0 +1,29 @@
+#!/usr/bin/env zx
+
+// Mollusk conformance testing of this Core BPF Feature Gate program against
+// the version running on mainnet-beta.
+
+import 'zx/globals';
+import { getProgramId, getProgramSharedObjectPath, workingDirectory } from '../utils.mjs';
+
+const programId = getProgramId('program');
+const programBinaryPath = getProgramSharedObjectPath('program');
+const baseBinaryDirPath = path.join(workingDirectory, 'target', 'dump-solana');
+const baseBinaryPath = path.join(baseBinaryDirPath, 'base.so');
+const molluskFixturesPath = path.join(workingDirectory, 'program', 'fuzz', 'blob');
+
+// Clone the program from mainnet-beta.
+await $`mkdir -p ${baseBinaryDirPath}`;
+await $`solana program dump -um ${programId} ${baseBinaryPath}`;
+
+// Test this program against the cloned program for conformance with Mollusk.
+let output = await $`mollusk run-test \
+    --proto firedancer --ignore-compute-units \
+    ${baseBinaryPath} ${programBinaryPath} \
+    ${molluskFixturesPath} ${programId}`;
+
+// The last line of output should exactly match the following:
+// [DONE][TEST RESULT]: 0 failures
+if (!output.stdout.includes("[DONE][TEST RESULT]: 0 failures")) {
+    throw new Error(`Error: mismatches detected.`);
+}

--- a/scripts/utils.mjs
+++ b/scripts/utils.mjs
@@ -70,6 +70,27 @@ export function getAllProgramFolders() {
   );
 }
 
+export function getProgramId(folder) {
+  return getCargoMetadata(folder)?.solana?.['program-id'];
+}
+
+export function getProgramName(folder) {
+  return getCargo(folder).package?.name;
+}
+
+export function getProgramSharedObjectName(folder) {
+  return `${getProgramName(folder).replace(/-/g, '_')}.so`;
+}
+
+export function getProgramSharedObjectPath(folder) {
+  return path.join(
+    workingDirectory,
+    'target',
+    'deploy',
+    getProgramSharedObjectName(folder),
+  );
+}
+
 export function getCargo(folder) {
   return parseToml(
     fs.readFileSync(


### PR DESCRIPTION
Similar to Address Lookup Table and Config, this PR sets up conformance testing with Mollusk for the Feature Gate program.

However, we have a CU mismatch to contend with right out of the gate.

The binary that was written to all three buffer accounts (testnet, devnet, mainnet-beta) came from [this release](https://github.com/solana-program/feature-gate/releases/tag/program%40v0.0.1), which is tied to [this commit](https://github.com/solana-program/feature-gate/commit/da848e43ec8ec7623d5679bd627fb70125a77866).

Since then, a few commits have updated the lockfile in this repository, causing the patch version of `solana-program` to change, like [this one](https://github.com/solana-program/feature-gate/commit/84dad041aadd0342ff81bf1917019a4891099cc5).

This has resulted in a CU mismatch for one test case of the four unit tests present, hence the need for the `--ignore-compute-units` CLI argument in the script.

As a side note, `--ignore-compute-units` is probably what we want for all repositories, since their dependency versions will change, and that should simply be recorded in a benchmark (in the markdown file) rather than producing a CI failure. When that day comes for the other programs, we can update it.