### PR TITLE
Add repository field to the JS client package.json

### DIFF
--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -2,7 +2,15 @@
     "name": "@solana-program/feature-gate",
     "version": "0.0.0",
     "description": "JavaScript client for the Feature Gate program",
+    "homepage": "https://github.com/solana-program/feature-gate#readme",
+    "bugs": {
+        "url": "https://github.com/solana-program/feature-gate/issues"
+    },
     "license": "MIT",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/solana-program/feature-gate.git"
+    },
     "files": [
         "./dist/src",
         "./dist/types"


### PR DESCRIPTION
This PR adds the missing `repository` field (along with `homepage` and `bugs`) to the JS client's `package.json`. Without it, npm rejects publishing with a provenance verification error (`E422`) because the empty `repository.url` doesn't match the repository embedded in the GitHub Actions provenance statement. This aligns the package metadata with the other repos in the solana-program org.