### PR TITLE
Bump Rust toolchain to 1.93.1

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.89.0"
+channel = "1.93.1"


### PR DESCRIPTION
This PR bumps the pinned stable Rust channel from 1.89.0 to 1.93.1, matching the rest of the fleet. The Regression Programs CI job installs the latest `mollusk-svm-cli`, whose `solana-syscalls` dependency (4.2.0, published August 7th) uses `MaybeUninit::write_copy_of_slice`, which is not stable on 1.89 — so the job fails on any branch, including main.

Blocking https://github.com/solana-program/feature-gate/pull/84, fixes CI 